### PR TITLE
feat: command palette (#12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "framer-motion": "^12.31.0",
     "next": "^16.0.7",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       framer-motion:
         specifier: ^12.31.0
         version: 12.31.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -491,6 +494,199 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -851,6 +1047,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -965,6 +1165,12 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1031,6 +1237,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -1285,6 +1494,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -1817,6 +2030,36 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.1:
     resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
@@ -2069,6 +2312,26 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2484,6 +2747,165 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.1)
+      aria-hidden: 1.2.6
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-remove-scroll: 2.7.2(@types/react@19.1.8)(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.8)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
   '@rtsao/scc@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -2771,6 +3193,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -2913,6 +3339,18 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cmdk@1.1.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2974,6 +3412,8 @@ snapshots:
       object-keys: 1.1.1
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -3384,6 +3824,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -3881,6 +4323,33 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.1.8)(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-style-singleton: 2.2.3(@types/react@19.1.8)(react@19.2.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  react-remove-scroll@2.7.2(@types/react@19.1.8)(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.8)(react@19.2.1)
+      react-style-singleton: 2.2.3(@types/react@19.1.8)(react@19.2.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.1.8)(react@19.2.1)
+      use-sidecar: 1.1.3(@types/react@19.1.8)(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  react-style-singleton@2.2.3(@types/react@19.1.8)(react@19.2.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
   react@19.2.1: {}
 
   reflect.getprototypeof@1.0.10:
@@ -4246,6 +4715,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.1.8)(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  use-sidecar@1.1.3(@types/react@19.1.8)(react@19.2.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.8
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,29 +82,29 @@ body {
   --radius: 0.5rem;
 
   --background: #fdf6e3;
-  --foreground: #000000;
+  --foreground: oklch(18% 0.018 85);
 
-  --card: oklch(92.932% 0.03182 187.079);
-  --card-foreground: oklch(20% 0.025 200);
+  --card: oklch(93% 0.022 85);
+  --card-foreground: oklch(20% 0.018 85);
 
-  --popover: oklch(97% 0.02 185);
-  --popover-foreground: oklch(20% 0.025 200);
+  --popover: oklch(97% 0.018 88);
+  --popover-foreground: oklch(20% 0.018 85);
 
   --primary: oklch(55% 0.18 179);
   --primary-foreground: oklch(97.317% 0.01625 183.114);
 
-  --secondary: oklch(82% 0.06 185);
-  --secondary-foreground: oklch(25% 0.04 185);
+  --secondary: oklch(84% 0.035 85);
+  --secondary-foreground: oklch(25% 0.025 85);
 
-  --accent: oklch(62% 0.24 320);
-  --accent-foreground: oklch(98% 0.01 320);
+  --accent: oklch(60% 0.2 290);
+  --accent-foreground: oklch(18% 0.012 290);
 
-  --muted: oklch(88% 0.025 185);
-  --muted-foreground: oklch(45% 0.035 190);
+  --muted: oklch(89% 0.018 85);
+  --muted-foreground: oklch(47% 0.022 85);
 
-  --border: oklch(78% 0.045 185);
+  --border: oklch(80% 0.025 85);
 
-  --input: oklch(72% 0.055 185);
+  --input: oklch(75% 0.03 85);
 
   --ring: oklch(55% 0.18 179);
 
@@ -112,18 +112,18 @@ body {
   --destructive-foreground: oklch(98% 0.01 25);
 
   --chart-1: oklch(55% 0.18 179);
-  --chart-2: oklch(62% 0.22 320);
+  --chart-2: oklch(60% 0.2 290);
   --chart-3: oklch(60% 0.15 160);
-  --chart-4: oklch(58% 0.18 280);
+  --chart-4: oklch(58% 0.18 68);
   --chart-5: oklch(52% 0.16 220);
 
-  --sidebar: oklch(82.224% 0.06902 182.012);
-  --sidebar-foreground: oklch(25% 0.03 200);
+  --sidebar: oklch(84% 0.035 85);
+  --sidebar-foreground: oklch(25% 0.02 85);
   --sidebar-primary: oklch(55% 0.16 185);
   --sidebar-primary-foreground: oklch(98% 0.01 185);
-  --sidebar-accent: oklch(87.247% 0.03525 187.762);
-  --sidebar-accent-foreground: oklch(25% 0.04 185);
-  --sidebar-border: oklch(80% 0.04 185);
+  --sidebar-accent: oklch(89% 0.018 85);
+  --sidebar-accent-foreground: oklch(25% 0.022 85);
+  --sidebar-border: oklch(82% 0.022 85);
   --sidebar-ring: oklch(55% 0.16 185);
 
   --shadow-color: #000000;
@@ -160,27 +160,27 @@ body {
   --background: #1c1b18;
   --foreground: oklch(92% 0.008 80);
 
-  --card: oklch(27.053% 0.00875 184.787);
-  --card-foreground: oklch(92% 0.012 190);
+  --card: oklch(26% 0.012 82);
+  --card-foreground: oklch(90% 0.01 82);
 
-  --popover: oklch(37.055% 0.02404 196.26);
-  --popover-foreground: oklch(92% 0.012 190);
+  --popover: oklch(34% 0.014 82);
+  --popover-foreground: oklch(90% 0.01 82);
 
   --primary: oklch(70% 0.18 179);
   --primary-foreground: oklch(15% 0.01 240);
 
-  --secondary: oklch(25% 0.04 185);
-  --secondary-foreground: oklch(85% 0.06 185);
+  --secondary: oklch(24% 0.022 82);
+  --secondary-foreground: oklch(84% 0.04 82);
 
-  --accent: oklch(68% 0.24 320);
-  --accent-foreground: oklch(15% 0.01 240);
+  --accent: oklch(65% 0.2 290);
+  --accent-foreground: oklch(15% 0.01 290);
 
-  --muted: oklch(25% 0.012 195);
-  --muted-foreground: oklch(65% 0.015 190);
+  --muted: oklch(24% 0.012 82);
+  --muted-foreground: oklch(64% 0.014 82);
 
-  --border: oklch(38% 0.02 195);
+  --border: oklch(36% 0.016 82);
 
-  --input: oklch(42% 0.025 195);
+  --input: oklch(40% 0.02 82);
 
   --ring: oklch(70% 0.18 179);
 
@@ -188,18 +188,18 @@ body {
   --destructive-foreground: oklch(98% 0.01 25);
 
   --chart-1: oklch(70% 0.18 179);
-  --chart-2: oklch(68% 0.24 320);
+  --chart-2: oklch(68% 0.22 290);
   --chart-3: oklch(72% 0.16 160);
-  --chart-4: oklch(65% 0.2 280);
+  --chart-4: oklch(65% 0.18 68);
   --chart-5: oklch(62% 0.18 220);
 
-  --sidebar: oklch(24.464% 0.00446 197.211);
-  --sidebar-foreground: oklch(88% 0.015 190);
+  --sidebar: oklch(22% 0.012 82);
+  --sidebar-foreground: oklch(86% 0.012 82);
   --sidebar-primary: oklch(70% 0.15 185);
-  --sidebar-primary-foreground: oklch(28% 0.015 195);
-  --sidebar-accent: oklch(49.298% 0.04132 191.571);
-  --sidebar-accent-foreground: oklch(75% 0.08 185);
-  --sidebar-border: oklch(41.838% 0.01891 196.592);
+  --sidebar-primary-foreground: oklch(28% 0.012 82);
+  --sidebar-accent: oklch(30% 0.015 82);
+  --sidebar-accent-foreground: oklch(75% 0.012 82);
+  --sidebar-border: oklch(34% 0.014 82);
   --sidebar-ring: oklch(70% 0.15 185);
 
   --shadow-color: #000000;

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -3,8 +3,13 @@ import React, { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { IconLayoutSidebarRightExpandFilled, IconX } from "@tabler/icons-react";
+import {
+  IconLayoutSidebarRightExpandFilled,
+  IconX,
+  IconSearch,
+} from "@tabler/icons-react";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import CommandPalette from "@/components/ui/command-palette";
 
 const navLinks = [
   { href: "/", label: "Home" },
@@ -16,6 +21,7 @@ const navLinks = [
 export default function Navbar() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
 
   return (
     <>
@@ -47,19 +53,36 @@ export default function Navbar() {
               </Link>
             );
           })}
+          <button
+            onClick={() => setPaletteOpen(true)}
+            className="text-foreground/70 hover:text-foreground transition-colors duration-200"
+            aria-label="Open command palette"
+          >
+            <IconSearch stroke={2} className="w-5 h-5" />
+          </button>
           <ThemeToggle />
         </div>
 
-        <button
-          className="sm:hidden p-2"
-          onClick={() => setMobileOpen(true)}
-          aria-label="Open menu"
-        >
-          <IconLayoutSidebarRightExpandFilled
-            stroke={2}
-            className="w-6 h-6 text-foreground"
-          />
-        </button>
+        {/* mobile right-side buttons */}
+        <div className="sm:hidden flex items-center gap-1">
+          <button
+            onClick={() => setPaletteOpen(true)}
+            className="p-2 text-foreground/70 hover:text-foreground transition-colors duration-200"
+            aria-label="Open command palette"
+          >
+            <IconSearch stroke={2} className="w-6 h-6" />
+          </button>
+          <button
+            className="p-2"
+            onClick={() => setMobileOpen(true)}
+            aria-label="Open menu"
+          >
+            <IconLayoutSidebarRightExpandFilled
+              stroke={2}
+              className="w-6 h-6 text-foreground"
+            />
+          </button>
+        </div>
       </nav>
 
       {mobileOpen && (
@@ -92,6 +115,8 @@ export default function Navbar() {
           </div>
         </div>
       )}
+
+      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
     </>
   );
 }

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -55,10 +55,16 @@ export default function Navbar() {
           })}
           <button
             onClick={() => setPaletteOpen(true)}
-            className="text-foreground/70 hover:text-foreground transition-colors duration-200"
+            className="flex items-center gap-1 text-[13px] font-medium text-foreground/75 bg-background border border-border px-2 py-1 rounded-lg hover:bg-foreground/3 hover:border-foreground/20 hover:text-foreground transition-colors duration-200"
             aria-label="Open command palette"
           >
-            <IconSearch stroke={2} className="w-5 h-5" />
+            <kbd className="px-1.5 py-1 rounded-sm bg-foreground/10 font-mono text-base leading-none">
+              ⌘
+            </kbd>
+            <span>+</span>
+            <kbd className="px-1.5 py-0.5 rounded-sm bg-foreground/10 font-mono">
+              K
+            </kbd>
           </button>
           <ThemeToggle />
         </div>

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -48,8 +48,19 @@ export default function CommandPalette({
   const [copied, setCopied] = useState(false);
   const [mounted, setMounted] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const chordRef = useRef<string | null>(null);
+  const chordTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const routerRef = useRef(router);
+  const onOpenChangeRef = useRef(onOpenChange);
   const isMobile = useIsMobile();
   const isDark = theme === "dark";
+
+  useEffect(() => {
+    routerRef.current = router;
+  }, [router]);
+  useEffect(() => {
+    onOpenChangeRef.current = onOpenChange;
+  }, [onOpenChange]);
 
   useEffect(() => setMounted(true), []);
 
@@ -66,6 +77,41 @@ export default function CommandPalette({
     window.addEventListener("keydown", down);
     return () => window.removeEventListener("keydown", down);
   }, [open, onOpenChange]);
+
+  // R → H/A/P sequence, global
+  useEffect(() => {
+    const routes: Record<string, string> = {
+      h: "/",
+      a: "/about",
+      p: "/projects",
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.repeat) return;
+      const key = e.key.toLowerCase();
+      if (key === "r") {
+        chordRef.current = "r";
+        if (chordTimerRef.current) clearTimeout(chordTimerRef.current);
+        chordTimerRef.current = setTimeout(() => {
+          chordRef.current = null;
+        }, 800);
+      } else if (chordRef.current === "r" && routes[key]) {
+        if (chordTimerRef.current) clearTimeout(chordTimerRef.current);
+        chordRef.current = null;
+        e.preventDefault();
+        routerRef.current.push(routes[key]);
+        onOpenChangeRef.current(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   // focus input on desktop
   useEffect(() => {
@@ -183,27 +229,42 @@ export default function CommandPalette({
                   )}
                 </div>
 
-                <Command.List className="overflow-y-auto scroll-smooth overscroll-contain scrollbar-thin p-2 max-h-[58vh] sm:max-h-72" style={{ scrollbarWidth: "thin", scrollbarColor: "oklch(from var(--foreground) l c h / 0.15) transparent" }}>
+                <Command.List
+                  className="overflow-y-auto scroll-smooth overscroll-contain scrollbar-thin p-2 max-h-[58vh] sm:max-h-72"
+                  style={{
+                    scrollbarWidth: "thin",
+                    scrollbarColor:
+                      "oklch(from var(--foreground) l c h / 0.15) transparent",
+                  }}
+                >
                   <Command.Empty className="py-8 text-center text-sm text-foreground/50">
                     No results found.
                   </Command.Empty>
 
                   <Command.Group heading="Navigate" className={groupClass}>
                     {[
-                      { id: "home", label: "Home", icon: IconHome, href: "/" },
+                      {
+                        id: "home",
+                        label: "Home",
+                        icon: IconHome,
+                        href: "/",
+                        shortcut: ["R", "H"],
+                      },
                       {
                         id: "about",
                         label: "About",
                         icon: IconUser,
                         href: "/about",
+                        shortcut: ["R", "A"],
                       },
                       {
                         id: "projects",
                         label: "Projects",
                         icon: IconFolder,
                         href: "/projects",
+                        shortcut: ["R", "P"],
                       },
-                    ].map(({ id, label, icon: Icon, href }) => (
+                    ].map(({ id, label, icon: Icon, href, shortcut }) => (
                       <Command.Item
                         key={id}
                         value={label}
@@ -211,7 +272,20 @@ export default function CommandPalette({
                         className={itemClass}
                       >
                         <Icon stroke={2} className="w-4 h-4 shrink-0" />
-                        {label}
+                        <span className="flex-1">{label}</span>
+                        {!isMobile && (
+                          <span className="flex items-center gap-1">
+                            <kbd className="font-mono text-xs text-foreground/70 bg-foreground/10 px-1.5 py-0.5 rounded-sm">
+                              {shortcut[0]}
+                            </kbd>
+                            <span className="text-xs text-foreground/50">
+                              then
+                            </span>
+                            <kbd className="font-mono text-xs text-foreground/70 bg-foreground/10 px-1.5 py-0.5 rounded-sm">
+                              {shortcut[1]}
+                            </kbd>
+                          </span>
+                        )}
                       </Command.Item>
                     ))}
                   </Command.Group>
@@ -288,7 +362,7 @@ export default function CommandPalette({
       <AnimatePresence>
         {copied && (
           <motion.div
-            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[300] bg-foreground text-background text-xs font-medium px-4 py-2 rounded-full shadow-lg whitespace-nowrap"
+            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[300] bg-foreground/80 text-background text-xs font-medium px-4 py-2 rounded-full shadow-lg whitespace-nowrap"
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 8 }}

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Command } from "cmdk";
+import { useRouter } from "next/navigation";
+import { useTheme } from "next-themes";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  IconSearch,
+  IconHome,
+  IconUser,
+  IconFolder,
+  IconBrandGithub,
+  IconBrandLinkedin,
+  IconMail,
+  IconFileText,
+  IconCalendar,
+  IconSun,
+  IconMoon,
+} from "@tabler/icons-react";
+import { externalLinks } from "@/data/links";
+
+const EMAIL = "rickytangdev@gmail.com";
+
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 640);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, []);
+  return isMobile;
+};
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function CommandPalette({
+  open,
+  onOpenChange,
+}: CommandPaletteProps) {
+  const router = useRouter();
+  const { theme, setTheme } = useTheme();
+  const [copied, setCopied] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isMobile = useIsMobile();
+  const isDark = theme === "dark";
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        onOpenChange(true);
+      }
+      if (e.key === "Escape" && open) {
+        onOpenChange(false);
+      }
+    };
+    window.addEventListener("keydown", down);
+    return () => window.removeEventListener("keydown", down);
+  }, [open, onOpenChange]);
+
+  // focus input on desktop
+  useEffect(() => {
+    if (open && !isMobile) {
+      const t = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [open, isMobile]);
+
+  const close = () => onOpenChange(false);
+
+  const copyEmail = async () => {
+    try {
+      await navigator.clipboard.writeText(EMAIL);
+    } catch {
+      // fallback for non-secure contexts
+      const el = document.createElement("input");
+      el.value = EMAIL;
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand("copy");
+      document.body.removeChild(el);
+    }
+    close();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const navigate = (href: string) => {
+    router.push(href);
+    close();
+  };
+
+  const openLink = (url: string) => {
+    window.open(url, "_blank", "noopener noreferrer");
+    close();
+  };
+
+  const toggleTheme = () => {
+    setTheme(isDark ? "light" : "dark");
+    close();
+  };
+
+  const panelVariants = isMobile
+    ? {
+        hidden: { y: "100%" },
+        visible: { y: 0 },
+        exit: { y: "100%" },
+      }
+    : {
+        hidden: { opacity: 0, scale: 0.97, y: -6 },
+        visible: { opacity: 1, scale: 1, y: 0 },
+        exit: { opacity: 0, scale: 0.97, y: -6 },
+      };
+
+  const itemClass =
+    "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm cursor-pointer text-foreground/80 data-[selected=true]:bg-primary/10 data-[selected=true]:text-primary transition-colors duration-100 outline-none";
+
+  const groupClass =
+    "[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:pt-3 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-foreground/40 [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:select-none";
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <>
+      <AnimatePresence>
+        {open && (
+          <>
+            {/* backdrop */}
+            <motion.div
+              className="fixed inset-0 z-[200] bg-black/30 backdrop-blur-sm"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              onClick={close}
+            />
+
+            {/* panel */}
+            <motion.div
+              className={`fixed z-[201] bg-background border border-border shadow-xl overflow-hidden ${
+                isMobile
+                  ? "bottom-0 left-0 right-0 rounded-t-2xl"
+                  : "top-[18%] left-1/2 -translate-x-1/2 w-full max-w-lg rounded-xl"
+              }`}
+              variants={panelVariants}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+              transition={{ type: "spring", stiffness: 400, damping: 40 }}
+            >
+              {/* mobile drag handle */}
+              {isMobile && (
+                <div className="flex justify-center pt-3 pb-1">
+                  <div className="w-10 h-1 rounded-full bg-foreground/20" />
+                </div>
+              )}
+
+              <Command>
+                {/* search bar */}
+                <div className="flex items-center gap-2 px-4 border-b border-border">
+                  <IconSearch
+                    stroke={2}
+                    className="w-4 h-4 text-foreground/50 shrink-0"
+                  />
+                  <Command.Input
+                    ref={inputRef}
+                    placeholder="Search..."
+                    className="flex-1 bg-transparent py-4 text-sm outline-none placeholder:text-foreground/40"
+                  />
+                  {!isMobile && (
+                    <kbd className="shrink-0 text-[10px] text-foreground/40 border border-border rounded px-1.5 py-0.5 font-mono">
+                      ESC
+                    </kbd>
+                  )}
+                </div>
+
+                <Command.List className="overflow-y-auto p-2 max-h-[58vh] sm:max-h-72">
+                  <Command.Empty className="py-8 text-center text-sm text-foreground/50">
+                    No results found.
+                  </Command.Empty>
+
+                  <Command.Group heading="Navigate" className={groupClass}>
+                    {[
+                      { id: "home", label: "Home", icon: IconHome, href: "/" },
+                      {
+                        id: "about",
+                        label: "About",
+                        icon: IconUser,
+                        href: "/about",
+                      },
+                      {
+                        id: "projects",
+                        label: "Projects",
+                        icon: IconFolder,
+                        href: "/projects",
+                      },
+                    ].map(({ id, label, icon: Icon, href }) => (
+                      <Command.Item
+                        key={id}
+                        value={label}
+                        onSelect={() => navigate(href)}
+                        className={itemClass}
+                      >
+                        <Icon stroke={2} className="w-4 h-4 shrink-0" />
+                        {label}
+                      </Command.Item>
+                    ))}
+                  </Command.Group>
+
+                  <Command.Group heading="Links" className={groupClass}>
+                    {[
+                      {
+                        id: "github",
+                        label: "GitHub",
+                        icon: IconBrandGithub,
+                        url: externalLinks.github,
+                      },
+                      {
+                        id: "linkedin",
+                        label: "LinkedIn",
+                        icon: IconBrandLinkedin,
+                        url: externalLinks.linkedin,
+                      },
+                      {
+                        id: "resume",
+                        label: "Resume",
+                        icon: IconFileText,
+                        url: "/Ricky_Tang_resume.pdf",
+                      },
+                      {
+                        id: "calcom",
+                        label: "Book a Call",
+                        icon: IconCalendar,
+                        url: externalLinks.calcom,
+                      },
+                    ].map(({ id, label, icon: Icon, url }) => (
+                      <Command.Item
+                        key={id}
+                        value={label}
+                        onSelect={() => openLink(url)}
+                        className={itemClass}
+                      >
+                        <Icon stroke={2} className="w-4 h-4 shrink-0" />
+                        {label}
+                      </Command.Item>
+                    ))}
+                    <Command.Item
+                      value="Copy Email"
+                      onSelect={copyEmail}
+                      className={itemClass}
+                    >
+                      <IconMail stroke={2} className="w-4 h-4 shrink-0" />
+                      Copy Email
+                    </Command.Item>
+                  </Command.Group>
+
+                  <Command.Group heading="Appearance" className={groupClass}>
+                    <Command.Item
+                      value="Toggle Theme"
+                      onSelect={toggleTheme}
+                      className={itemClass}
+                    >
+                      {isDark ? (
+                        <IconSun stroke={2} className="w-4 h-4 shrink-0" />
+                      ) : (
+                        <IconMoon stroke={2} className="w-4 h-4 shrink-0" />
+                      )}
+                      {isDark ? "Switch to Light" : "Switch to Dark"}
+                    </Command.Item>
+                  </Command.Group>
+                </Command.List>
+              </Command>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+
+      {/* copy toast */}
+      <AnimatePresence>
+        {copied && (
+          <motion.div
+            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[300] bg-foreground text-background text-xs font-medium px-4 py-2 rounded-full shadow-lg whitespace-nowrap"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            transition={{ duration: 0.2 }}
+          >
+            email copied!
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>,
+    document.body,
+  );
+}

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { Command } from "cmdk";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useTheme } from "next-themes";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -44,6 +44,7 @@ export default function CommandPalette({
   onOpenChange,
 }: CommandPaletteProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const { theme, setTheme } = useTheme();
   const [copied, setCopied] = useState(false);
   const mounted = useSyncExternalStore(() => () => {}, () => true, () => false);
@@ -271,6 +272,9 @@ export default function CommandPalette({
                       >
                         <Icon stroke={2} className="w-4 h-4 shrink-0" />
                         <span className="flex-1">{label}</span>
+                        {pathname === href && (
+                          <span className="w-1.5 h-1.5 rounded-full bg-primary/50 shrink-0" />
+                        )}
                         {!isMobile && (
                           <span className="flex items-center gap-1">
                             <kbd className="font-mono text-xs text-foreground/70 bg-foreground/10 px-1.5 py-0.5 rounded-sm">

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -177,7 +177,7 @@ export default function CommandPalette({
                     className="flex-1 bg-transparent py-4 text-sm outline-none placeholder:text-foreground/40"
                   />
                   {!isMobile && (
-                    <kbd className="shrink-0 text-[10px] text-foreground/40 border border-border rounded px-1.5 py-0.5 font-mono">
+                    <kbd className="shrink-0 font-mono text-[11px] text-foreground/50 bg-muted px-1.5 py-0.5 rounded-sm">
                       ESC
                     </kbd>
                   )}
@@ -217,6 +217,14 @@ export default function CommandPalette({
                   </Command.Group>
 
                   <Command.Group heading="Links" className={groupClass}>
+                    <Command.Item
+                      value="Copy Email"
+                      onSelect={copyEmail}
+                      className={itemClass}
+                    >
+                      <IconMail stroke={2} className="w-4 h-4 shrink-0" />
+                      Copy Email
+                    </Command.Item>
                     {[
                       {
                         id: "github",
@@ -253,14 +261,6 @@ export default function CommandPalette({
                         {label}
                       </Command.Item>
                     ))}
-                    <Command.Item
-                      value="Copy Email"
-                      onSelect={copyEmail}
-                      className={itemClass}
-                    >
-                      <IconMail stroke={2} className="w-4 h-4 shrink-0" />
-                      Copy Email
-                    </Command.Item>
                   </Command.Group>
 
                   <Command.Group heading="Appearance" className={groupClass}>

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -177,13 +177,13 @@ export default function CommandPalette({
                     className="flex-1 bg-transparent py-4 text-sm outline-none placeholder:text-foreground/40"
                   />
                   {!isMobile && (
-                    <kbd className="shrink-0 font-mono text-[11px] text-foreground/50 bg-muted px-1.5 py-0.5 rounded-sm">
+                    <kbd className="shrink-0 font-mono text-[11px] text-foreground/70 bg-foreground/15 px-1.5 py-0.5 rounded-sm">
                       ESC
                     </kbd>
                   )}
                 </div>
 
-                <Command.List className="overflow-y-auto scroll-smooth p-2 max-h-[58vh] sm:max-h-72">
+                <Command.List className="overflow-y-auto scroll-smooth overscroll-contain scrollbar-thin p-2 max-h-[58vh] sm:max-h-72" style={{ scrollbarWidth: "thin", scrollbarColor: "oklch(from var(--foreground) l c h / 0.15) transparent" }}>
                   <Command.Empty className="py-8 text-center text-sm text-foreground/50">
                     No results found.
                   </Command.Empty>
@@ -265,7 +265,7 @@ export default function CommandPalette({
 
                   <Command.Group heading="Appearance" className={groupClass}>
                     <Command.Item
-                      value="Toggle Theme"
+                      value={isDark ? "Switch to Light" : "Switch to Dark"}
                       onSelect={toggleTheme}
                       className={itemClass}
                     >

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -122,7 +122,7 @@ export default function CommandPalette({
       };
 
   const itemClass =
-    "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm cursor-pointer text-foreground/80 data-[selected=true]:bg-primary/10 data-[selected=true]:text-primary transition-colors duration-100 outline-none";
+    "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm cursor-pointer text-foreground/80 aria-selected:bg-primary/10 aria-selected:text-primary transition-colors duration-100 outline-none";
 
   const groupClass =
     "[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:pt-3 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-foreground/40 [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:select-none";
@@ -183,7 +183,7 @@ export default function CommandPalette({
                   )}
                 </div>
 
-                <Command.List className="overflow-y-auto p-2 max-h-[58vh] sm:max-h-72">
+                <Command.List className="overflow-y-auto scroll-smooth p-2 max-h-[58vh] sm:max-h-72">
                   <Command.Empty className="py-8 text-center text-sm text-foreground/50">
                     No results found.
                   </Command.Empty>

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { Command } from "cmdk";
 import { useRouter } from "next/navigation";
@@ -46,7 +46,7 @@ export default function CommandPalette({
   const router = useRouter();
   const { theme, setTheme } = useTheme();
   const [copied, setCopied] = useState(false);
-  const [mounted, setMounted] = useState(false);
+  const mounted = useSyncExternalStore(() => () => {}, () => true, () => false);
   const inputRef = useRef<HTMLInputElement>(null);
   const chordRef = useRef<string | null>(null);
   const chordTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -61,8 +61,6 @@ export default function CommandPalette({
   useEffect(() => {
     onOpenChangeRef.current = onOpenChange;
   }, [onOpenChange]);
-
-  useEffect(() => setMounted(true), []);
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {


### PR DESCRIPTION
- add a shadcn command palette. with all pages routes, important links, and theme toggle. cohesive to website theme
- on mobile it's search icon (palette slides from bottom) and on desktop it's cmd + k
- also tweaked globals.css for a warmer website theme

resolves #12 